### PR TITLE
detect if a pid exists before signaling it

### DIFF
--- a/seamless.go
+++ b/seamless.go
@@ -124,7 +124,8 @@ func stage1() {
 	}
 	// At this point, we are ready to inform our parent that it can start the
 	// new instance.
-	if p, err := os.FindProcess(os.Getppid()); err == nil {
+	p, _ := os.FindProcess(os.Getppid())
+	if err := p.Signal(syscall.Signal(0)); err == nil {
 		if err = p.Signal(syscall.SIGCHLD); err != nil {
 			LogError("Could not send SIGCHLD to parent process", err)
 		}
@@ -175,7 +176,8 @@ func Started() {
 		LogError("Notification error", fmt.Errorf("invalid PID file content: %v", err))
 		return
 	}
-	if p, err := os.FindProcess(pid); err == nil {
+	p, _ := os.FindProcess(pid)
+	if err := p.Signal(syscall.Signal(0)); err == nil {
 		if err = p.Signal(syscall.SIGTERM); err != nil {
 			LogError("Could not send SIGTERM to old process", err)
 		}


### PR DESCRIPTION
The code currently tries to detect if a pid exists and is able to be signaled before signaling it, however os.FindProcess() always succeeds on Unix. This change switches to using signal(0) to determine if the pid is live instead (as documented in the kill syscall's man page).

Previously, for a nonexistent pid:
  $ ./main
  2023/08/08 16:44:05 seamless: Starting child process
  2023/08/08 16:44:06 seamless: Notifying old process
  2023/08/08 16:44:06 seamless: Could not send SIGTERM to old process: os: process already finished

Now, for a nonexistent pid:
  $ ./main
  2023/08/08 16:41:55 seamless: Starting child process
  2023/08/08 16:41:56 seamless: Notifying old process
  2023/08/08 16:41:56 seamless: Could not find old process: os: process already finished