### PR TITLE
Expose APIs to accept callback on child process launch and to override parent term signal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/rs/seamless
+
+require golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/launcher.go
+++ b/launcher.go
@@ -37,6 +37,12 @@ func launch() {
 		LogError("Could not fork", err)
 		os.Exit(1)
 	}
+
+	// Execute callbacks post the daemon launch before starting signal handler
+	for _, f := range onChildDaemonLaunch {
+		f()
+	}
+
 	c := make(chan os.Signal, 10)
 	signal.Notify(c, syscall.SIGABRT, syscall.SIGALRM, syscall.SIGBUS, syscall.SIGCHLD,
 		syscall.SIGCONT, syscall.SIGFPE, syscall.SIGHUP, syscall.SIGILL, syscall.SIGINT,

--- a/launcher.go
+++ b/launcher.go
@@ -75,6 +75,8 @@ func launch() {
 				// Setup a timer after which the child is sent a SIGTERM if
 				// no SIGCHLD has been recieved.
 				timer = time.After(10 * time.Second)
+			case parentTermSignal:
+				fallthrough
 			case syscall.SIGCHLD:
 				if terminated {
 					os.Exit(0)

--- a/seamless.go
+++ b/seamless.go
@@ -69,6 +69,7 @@ var (
 	disabled             bool
 	doneCh               chan struct{}
 	pidFilePath          string
+	onChildDaemonLaunch  []func()
 	shutdownRequestFuncs []func()
 	shutdownFuncs        []func()
 )
@@ -223,6 +224,13 @@ func OnShutdownRequest(f func()) {
 // unblock.
 func OnShutdown(f func()) {
 	shutdownFuncs = append(shutdownFuncs, f)
+}
+
+// OnChildDaemonLaunch executes f() after successful launch of the child process
+// by the launcher. f() should not be blocking.
+// Typical use case include resource cleanups, logging etc.
+func OnChildDaemonLaunch(f func()) {
+	onChildDaemonLaunch = append(onChildDaemonLaunch, f)
 }
 
 // Wait blocks until the seamless restart is completed. This method should be

--- a/seamless.go
+++ b/seamless.go
@@ -43,7 +43,6 @@ package seamless
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -152,13 +151,13 @@ func Started() {
 	}
 
 	defer func() {
-		if err := ioutil.WriteFile(pidFilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+		if err := os.WriteFile(pidFilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
 			LogError("Could not create PID file", err)
 		}
 	}()
 
 	// This is stage 2 on the other (new) process.
-	b, err := ioutil.ReadFile(pidFilePath)
+	b, err := os.ReadFile(pidFilePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No pid file = no old process to notify.


### PR DESCRIPTION
Commits: 
- Use ListenConfig in net lib to bind with soreuseport option
Simple cleanups to use net lib to bind with soreuseport and remove external dependency. Also, replaces deprecated ioutil Read/Write calls with corresponding method in `os` package.

- Add callbacks to execute after launching of child daemon
Adds API to accept and execute callbacks to execute after successful launch of child daemon. This is useful to do any necessary resource cleanups, loggings etc.
 
- Enable user to override signal sent to the parent process
Allows user to override the SIGCHILD signal sent to the launcher process to terminate the parent process. In some operating systems like BSD, SIGCHILD can be restricted and can lead to permission errors on the child process.
This allows users to custom define this signal.